### PR TITLE
Fix various issues with table assignment UX

### DIFF
--- a/app/Filament/Resources/ApplicationResource.php
+++ b/app/Filament/Resources/ApplicationResource.php
@@ -120,7 +120,7 @@ class ApplicationResource extends Resource
                     'success' => ApplicationStatus::TableAccepted->value,
                     'danger' => ApplicationStatus::Canceled->value
                 ]),
-                Tables\Columns\TextColumn::make('requestedTable.name'),
+                Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
                 // FIXME: It is currently not possible to select 'null' to clear the assigned table here, therefore placeholder selection has been disabled.
                 Tables\Columns\SelectColumn::make('table_type_assigned')->options(TableType::pluck('name', 'id')->toArray())->disablePlaceholderSelection(),
                 Tables\Columns\TextColumn::make('type')->formatStateUsing(function (string $state) {

--- a/app/Filament/Resources/ApplicationResource.php
+++ b/app/Filament/Resources/ApplicationResource.php
@@ -118,12 +118,12 @@ class ApplicationResource extends Resource
                     'danger' => ApplicationStatus::Canceled->value
                 ]),
                 Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
-                Tables\Columns\SelectColumn::make('tableTypeAssignedAutoNull')->options(TableType::pluck('name', 'id')->toArray()),
+                Tables\Columns\SelectColumn::make('tableTypeAssignedAutoNull')->label('Assigned table')->options(TableType::pluck('name', 'id')->toArray()),
                 Tables\Columns\TextColumn::make('type')->formatStateUsing(function (string $state) {
                     return ucfirst($state);
                 })->sortable(),
                 Tables\Columns\TextInputColumn::make('table_number')->sortable()->searchable(),
-                Tables\Columns\IconColumn::make('is_ready')->getStateUsing(function (Application $record) {
+                Tables\Columns\IconColumn::make('is_ready')->label('Ready')->getStateUsing(function (Application $record) {
                     return $record->isReady();
                 })->boolean(),
                 Tables\Columns\TextColumn::make('dlrshp')->getStateUsing(function (Application $record) {

--- a/app/Filament/Resources/ApplicationResource.php
+++ b/app/Filament/Resources/ApplicationResource.php
@@ -10,9 +10,6 @@ use App\Filament\Resources\ApplicationResource\RelationManagers;
 use App\Http\Controllers\Applications\ApplicationController;
 use App\Models\Application;
 use App\Models\TableType;
-use App\Notifications\AcceptedNotification;
-use App\Notifications\OnHoldNotification;
-use App\Notifications\WaitingListNotification;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Resources\Form;
@@ -121,8 +118,7 @@ class ApplicationResource extends Resource
                     'danger' => ApplicationStatus::Canceled->value
                 ]),
                 Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
-                // FIXME: It is currently not possible to select 'null' to clear the assigned table here, therefore placeholder selection has been disabled.
-                Tables\Columns\SelectColumn::make('table_type_assigned')->options(TableType::pluck('name', 'id')->toArray()),
+                Tables\Columns\SelectColumn::make('tableTypeAssignedAutoNull')->options(TableType::pluck('name', 'id')->toArray()),
                 Tables\Columns\TextColumn::make('type')->formatStateUsing(function (string $state) {
                     return ucfirst($state);
                 })->sortable(),

--- a/app/Filament/Resources/ApplicationResource.php
+++ b/app/Filament/Resources/ApplicationResource.php
@@ -120,7 +120,7 @@ class ApplicationResource extends Resource
                     'success' => ApplicationStatus::TableAccepted->value,
                     'danger' => ApplicationStatus::Canceled->value
                 ]),
-                Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
+                Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->type === ApplicationType::Dealer && $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
                 // FIXME: It is currently not possible to select 'null' to clear the assigned table here, therefore placeholder selection has been disabled.
                 Tables\Columns\SelectColumn::make('table_type_assigned')->options(TableType::pluck('name', 'id')->toArray()),
                 Tables\Columns\TextColumn::make('type')->formatStateUsing(function (string $state) {

--- a/app/Filament/Resources/ApplicationResource.php
+++ b/app/Filament/Resources/ApplicationResource.php
@@ -122,7 +122,7 @@ class ApplicationResource extends Resource
                 ]),
                 Tables\Columns\TextColumn::make('requestedTable.name')->icon(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'heroicon-o-exclamation' : '')->iconPosition('after')->color(fn($record) => $record->table_type_requested !== $record->table_type_assigned ? 'warning' : ''),
                 // FIXME: It is currently not possible to select 'null' to clear the assigned table here, therefore placeholder selection has been disabled.
-                Tables\Columns\SelectColumn::make('table_type_assigned')->options(TableType::pluck('name', 'id')->toArray())->disablePlaceholderSelection(),
+                Tables\Columns\SelectColumn::make('table_type_assigned')->options(TableType::pluck('name', 'id')->toArray()),
                 Tables\Columns\TextColumn::make('type')->formatStateUsing(function (string $state) {
                     return ucfirst($state);
                 })->sortable(),

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -368,7 +368,10 @@ class Application extends Model
         }
 
         foreach ($dealership->children()->get() as $child) {
-            if ($child->status !== ApplicationStatus::Canceled && $child->status !== $dealership->status) {
+            if($child->status === ApplicationStatus::Canceled) {
+                continue;
+            }
+            if ($child->status !== $dealership->status) {
                 return false;
             }
             // table numbers must be identical

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -361,10 +361,14 @@ class Application extends Model
             return false;
         }
 
-        if ($this->type !== ApplicationType::Dealer) {
-            $dealership = $this->parent()->get()->first();
-        } else {
+        if ($this->type === ApplicationType::Dealer) {
             $dealership = $this;
+        } else {
+            $dealership = $this->parent()->get()->first();
+        }
+
+        if (!empty($dealership->table_number) && $dealership->table_type_assigned === null) {
+            return false;
         }
 
         foreach ($dealership->children()->get() as $child) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,7 +55,8 @@ class User extends Authenticatable implements FilamentUser
             "QL89R6583KNDG3WJ", // ???
             "M728WGE7ZJKJVO63", // ???
             "QL89R6580XKNDG3W", // Pattarchus(?)
-            "1243MK1XZWKXWJ68"  // Jul
+            "1243MK1XZWKXWJ68",  // Jul
+            "QL89R65833KNDG3W", // Fenrikur
         ]);
     }
 }


### PR DESCRIPTION
- fix isReady not ignoring canceled regs
- fix Dealers with table number but without assigned table being ready
- highlight when assigned != requested table
- fix placeholder option being removed entirely for assigned table column (reintroduces exception when selecting placeholder)
- highlight table mismatch only on Dealer
- workaround for clearing assigned table in overview (fix regression from placeholder)
- fix column labels on applications list