### PR TITLE
Add groups provided by IDP to User for authorization

### DIFF
--- a/app/Http/Controllers/Auth/OidcClientController.php
+++ b/app/Http/Controllers/Auth/OidcClientController.php
@@ -58,7 +58,7 @@ class OidcClientController extends Controller
             'code' => $data['code'],
         ]);
         $userinfoRequest = Http::identity()->withToken($accessToken->getToken())->get("/api/v1/userinfo");
-        if($userinfoRequest->successful() === false) {
+        if ($userinfoRequest->successful() === false) {
             return Redirect::route('auth.login');
         }
         $userinfo = $userinfoRequest->json()['data'];
@@ -74,11 +74,12 @@ class OidcClientController extends Controller
             "identity_id" => $userinfo['sub'],
             "name" => $userinfo['name'],
             "email" => $userinfo['email'],
+            "groups" => $userinfo['groups'],
         ]);
         $user = $user->fresh();
         Auth::loginUsingId($user->id);
         Session::put('access_token', $accessToken);
-        Session::put("avatar" , $userinfo['avatar']);
+        Session::put('avatar', $userinfo['avatar']);
         return $this->redirectDestination($request);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable implements FilamentUser
         'identity_id',
         'reg_id',
         'password',
+        'groups',
     ];
 
     /**
@@ -42,6 +43,7 @@ class User extends Authenticatable implements FilamentUser
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'groups' => 'array',
     ];
 
     public function application(): \Illuminate\Database\Eloquent\Relations\HasOne
@@ -51,13 +53,6 @@ class User extends Authenticatable implements FilamentUser
 
     public function canAccessFilament(): bool
     {
-        return in_array($this->identity_id, [
-            "QL89R6583KNDG3WJ", // ???
-            "M728WGE7ZJKJVO63", // ???
-            "QL89R6580XKNDG3W", // Pattarchus(?)
-            "1243MK1XZWKXWJ68", // Jul
-            "QL89R65833KNDG3W", // Fenrikur
-            "ZV9Q6Y5O30EO73P8", // Rakan
-        ]);
+        return in_array(config('ef.admin_group'), $this->groups);
     }
 }

--- a/config/ef.php
+++ b/config/ef.php
@@ -7,5 +7,7 @@ return [
     'idp_url' => 'https://identity.eurofurence.org',
     'dealers_email' => 'dealers@eurofurence.org',
     'con_name' => 'Eurofurence 27',
-    'payment_timeframe' => 'two weeks'
+    'payment_timeframe' => 'two weeks',
+    'admin_group' => 'QE3VMR2LK9X1PW07',
+    'frontdesk_group' => 'EN3GL42Q072JKZQO',
 ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,7 +20,8 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'identity_id' => fake()->uuid()
+            'identity_id' => fake()->uuid(),
+            'groups' => [],
         ];
     }
 

--- a/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
+++ b/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->json('groups')->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('groups');
+        });
+    }
+};

--- a/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
+++ b/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->json('groups')->default('[]');
+            $table->json('groups');
         });
     }
 

--- a/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
+++ b/database/migrations/2023_08_07_194554_add_groups_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->json('groups')->default(null);
+            $table->json('groups')->default('[]');
         });
     }
 


### PR DESCRIPTION
Use static group IDs instead of user IDs for authorization when accessing Filament-based admin frontend.