### PR TITLE
fix(export): npe during export

### DIFF
--- a/app/Enums/ApplicationStatus.php
+++ b/app/Enums/ApplicationStatus.php
@@ -28,7 +28,7 @@ enum ApplicationStatus: string
             )
             || (
                 $application->type !== \App\Enums\ApplicationType::Dealer
-                && !is_null($application->parent()->first()->waiting_at)
+                && !is_null($application->parent()->first()?->waiting_at)
             )
         ) {
             return ApplicationStatus::Waiting;
@@ -38,7 +38,7 @@ enum ApplicationStatus: string
             )
             || (
                 $application->type !== \App\Enums\ApplicationType::Dealer
-                && !is_null($application->parent()->first()->offer_accepted_at)
+                && !is_null($application->parent()->first()?->offer_accepted_at)
             )
         ) {
             return ApplicationStatus::TableAccepted;
@@ -48,7 +48,7 @@ enum ApplicationStatus: string
             )
             || (
                 $application->type !== \App\Enums\ApplicationType::Dealer
-                && !is_null($application->parent()->first()->offer_sent_at)
+                && !is_null($application->parent()->first()?->offer_sent_at)
             )
         ) {
             return ApplicationStatus::TableOffered;
@@ -60,7 +60,7 @@ enum ApplicationStatus: string
                 )
                 || (
                     $application->type !== \App\Enums\ApplicationType::Dealer
-                    && !empty($application->parent()->first()->table_type_assigned)
+                    && !empty($application->parent()->first()?->table_type_assigned)
                 )
             )
             && (

--- a/app/Http/Controllers/Applications/ApplicationController.php
+++ b/app/Http/Controllers/Applications/ApplicationController.php
@@ -273,17 +273,17 @@ class ApplicationController extends Controller
             'Pragma' => 'public'
         ];
 
-        $applications = Application::getAllApplicationsForExport();
+        $applications = Application::getAllApplicationsForExport()?->toArray();
 
         if (!empty($applications)) {
             # add table headers
-            array_unshift($applications, array_keys($applications[0]));
+            array_unshift($applications, array_keys((array)$applications[0]));
         }
 
         $callback = function () use ($applications) {
             $handle = fopen('php://output', 'w');
             foreach ($applications as $row) {
-                fputcsv($handle, $row);
+                fputcsv($handle, (array)$row);
             }
             fclose($handle);
         };
@@ -310,15 +310,15 @@ class ApplicationController extends Controller
 
         $csvFile = tmpfile();
         $csvFileUri = stream_get_meta_data($csvFile)['uri'];
-        $applications = Application::getAllApplicationsForAppExport();
+        $applications = Application::getAllApplicationsForAppExport()?->toArray();
 
         if (!empty($applications)) {
             # add table headers
-            array_unshift($applications, array_keys($applications[0]));
+            array_unshift($applications, array_keys((array)$applications[0]));
         }
 
         foreach ($applications as $row) {
-            fputcsv($csvFile, $row, $separator);
+            fputcsv($csvFile, (array)$row, $separator);
         }
         fflush($csvFile);
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use App\Enums\ApplicationStatus;
 use App\Enums\ApplicationType;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -338,15 +338,17 @@ class Application extends Model
             )->get();
     }
 
-    public static function getAllApplicationsForExport()
+    public static function getAllApplicationsForExport(): \Illuminate\Support\Collection
     {
-        $keywords = DB::table('profiles')
+        $keywords = Profile::query()->toBase()
             ->leftJoin('keyword_profile', 'keyword_profile.profile_id', '=', 'profiles.id')
             ->leftJoin('keywords', 'keywords.id', '=', 'keyword_profile.keyword_id')
             ->leftJoin('categories', 'keywords.id', '=', 'categories.id')
             ->groupBy('profiles.id')
             ->select(DB::raw('GROUP_CONCAT(`keywords`.`name` SEPARATOR \',\') AS `keywords`, GROUP_CONCAT(`categories`.`name` SEPARATOR \',\') AS `categories`, `profiles`.`id` AS `profile_id`'));
-        $applications = self::leftJoin('profiles', 'applications.id', '=', 'profiles.application_id')
+
+        $applications = self::query()->toBase()
+            ->leftJoin('profiles', 'applications.id', '=', 'profiles.application_id')
             ->leftJoin('users', 'user_id', '=', 'users.id')
             ->leftJoin('table_types AS t1', 'table_type_requested', '=', 't1.id')
             ->leftJoin('table_types AS t2', 'table_type_assigned', '=', 't2.id')
@@ -387,12 +389,13 @@ class Application extends Model
             )
             ->get();
 
-        return json_decode(json_encode($applications), true);
+        return $applications;
     }
 
-    public static function getAllApplicationsForAppExport()
+    public static function getAllApplicationsForAppExport(): \Illuminate\Support\Collection
     {
-        $applications = self::leftJoin('profiles', 'applications.id', '=', 'profiles.application_id')
+        $applications = self::query()->toBase()
+            ->leftJoin('profiles', 'applications.id', '=', 'profiles.application_id')
             ->leftJoin('users', 'user_id', '=', 'users.id')
             ->select(
                 'applications.id AS Reg No.',
@@ -438,7 +441,7 @@ class Application extends Model
                     ->orWhere('type', ApplicationType::Dealer);
             })
             ->get();
-        return json_decode(json_encode($applications), true);
+        return $applications;
     }
 
     /**


### PR DESCRIPTION
Export would fail because the export query would not resolve all expected fields, since they are not needed, but are expected during the instantiation of related model classes due to using the `Illuminate\Database\Eloquent\Builder` instead of the `Illuminate\Contracts\Database\Query\Builder` and doing a re-deserialisiation with `json_decode(json_encode())`.