### PR TITLE
feat!(export): export categorized keywords for apps

### DIFF
--- a/app/Http/Controllers/Applications/ApplicationController.php
+++ b/app/Http/Controllers/Applications/ApplicationController.php
@@ -368,6 +368,18 @@ class ApplicationController extends Controller
         }
 
         foreach ($applications as $row) {
+            if (!is_array($row) && !empty($row->Keywords)) {
+                $categorizedKeywords = array_reduce(explode('$$', $row->Keywords), function ($categorizedKeywords, $categoryKeyword) {
+                    list($category, $keyword) = explode('::', $categoryKeyword, 2);
+                    if (array_key_exists($category, $categorizedKeywords)) {
+                        array_push($categorizedKeywords[$category], $keyword);
+                    } else {
+                        $categorizedKeywords[$category] = [$keyword];
+                    }
+                    return $categorizedKeywords;
+                }, array());
+                $row->Keywords = json_encode($categorizedKeywords);
+            }
             fputcsv($csvFile, (array)$row, $separator);
         }
         fflush($csvFile);

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -433,7 +433,6 @@ class Application extends Model
                 DB::raw("CASE WHEN image_artist IS NOT NULL THEN 'X' ELSE '' END AS 'ArtistImg'"),
                 DB::raw("CASE WHEN image_art IS NOT NULL THEN 'X' ELSE '' END AS 'ArtImg'"),
                 'profile_keywords.categorized_keywords as Keywords',
-                'discord as Discord',
                 'tweet as Tweet',
                 'table_number as Table Number',
                 'type as Type',

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -343,7 +343,7 @@ class Application extends Model
         $keywords = Profile::query()->toBase()
             ->leftJoin('keyword_profile', 'keyword_profile.profile_id', '=', 'profiles.id')
             ->leftJoin('keywords', 'keywords.id', '=', 'keyword_profile.keyword_id')
-            ->leftJoin('categories', 'keywords.id', '=', 'categories.id')
+            ->leftJoin('categories', 'keywords.category_id', '=', 'categories.id')
             ->groupBy('profiles.id')
             ->select(DB::raw('GROUP_CONCAT(`keywords`.`name` SEPARATOR \',\') AS `keywords`, GROUP_CONCAT(`categories`.`name` SEPARATOR \',\') AS `categories`, `profiles`.`id` AS `profile_id`'));
 
@@ -395,9 +395,19 @@ class Application extends Model
 
     public static function getAllApplicationsForAppExport(): \Illuminate\Support\Collection
     {
+        $keywords = Profile::query()->toBase()
+            ->leftJoin('keyword_profile', 'keyword_profile.profile_id', '=', 'profiles.id')
+            ->leftJoin('keywords', 'keywords.id', '=', 'keyword_profile.keyword_id')
+            ->leftJoin('categories', 'keywords.category_id', '=', 'categories.id')
+            ->groupBy('profiles.id')
+            ->select(DB::raw('GROUP_CONCAT(CONCAT_WS(\'::\', `categories`.`name`, `keywords`.`name`) SEPARATOR \'$$\') AS `categorized_keywords`, `profiles`.`id` AS `profile_id`'));
+
         $applications = self::query()->toBase()
             ->leftJoin('profiles', 'applications.id', '=', 'profiles.application_id')
             ->leftJoin('users', 'user_id', '=', 'users.id')
+            ->leftJoinSub($keywords, 'profile_keywords', function (JoinClause $join) {
+                $join->on('profiles.id', '=', 'profile_keywords.profile_id');
+            })
             ->select(
                 'applications.id AS Reg No.',
                 'users.name AS Nick',
@@ -414,6 +424,7 @@ class Application extends Model
                 'art_desc AS About the Art',
                 'profiles.website as Website',
                 'twitter as Twitter',
+                'discord as Discord',
                 'mastodon as Mastodon',
                 'bluesky as Bluesky',
                 'telegram as Telegram',
@@ -421,12 +432,7 @@ class Application extends Model
                 DB::raw("CASE WHEN image_thumbnail IS NOT NULL THEN 'X' ELSE '' END AS 'ThumbailImg'"),
                 DB::raw("CASE WHEN image_artist IS NOT NULL THEN 'X' ELSE '' END AS 'ArtistImg'"),
                 DB::raw("CASE WHEN image_art IS NOT NULL THEN 'X' ELSE '' END AS 'ArtImg'"),
-                // TODO: Export keywords and categories once supported in app backend
-                DB::raw("'X' AS 'Cat. Prints'"),
-                DB::raw("'X' AS 'Cat. Artwork'"),
-                DB::raw("'X' AS 'Cat. Fursuit'"),
-                DB::raw("'X' AS 'Cat. Commissions'"),
-                DB::raw("'X' AS 'Cat. Misc'"),
+                'profile_keywords.categorized_keywords as Keywords',
                 'discord as Discord',
                 'tweet as Tweet',
                 'table_number as Table Number',


### PR DESCRIPTION
BREAKING CHANGE: export for apps returns JSON containing categorized keywords instead of fixed set of categories

Former export fields `Cat. Prints`, `Cat. Artwork`, `Cat. Fursuit`, `Cat. Commissions` and `Cat. Misc` replaced by field `Keywords` containing a JSON object with categories as keys and an array of applicable keywords for each category as value. UTF-8 characters will be escaped.

Example:
```json
{
	"Home and Bedding D\u00e9cor": [
		"Coasters",
		"Towels",
		"Furnishings (Other)"
	],
	"Music and Audio": [
		"Music and Audio (Other)"
	]
}
```