### PR TITLE
bugfix(db): Physical chairs initialization by migration was faulty

### DIFF
--- a/database/migrations/2025_08_12_213302_reset_and_invalidate_physical_chairs.php
+++ b/database/migrations/2025_08_12_213302_reset_and_invalidate_physical_chairs.php
@@ -12,7 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('applications', function (Blueprint $table) {
-            $table->integer('physical_chairs')->default(0);
+            $table->dropColumn('physical_chairs');
+            $table->integer('physical_chairs')->default(-1);
         });
     }
 
@@ -21,8 +22,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('applications', function (Blueprint $table) {
-            $table->dropColumn('physical_chairs');
-        });
+        //
     }
 };


### PR DESCRIPTION
Was faultily assigning zero chairs to existing migrations.
**This migration RESETS all chair assignments - this is intended behavior.**

Also fixes function Name in previous migration rollback handler for completeness.