### PR TITLE
feat(#185): Improve image upload in profile form.

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,3 +2,5 @@ import './bootstrap';
 import.meta.glob([
     '../assets/**',
 ]);
+
+import './imageUpload';

--- a/resources/js/imageUpload.js
+++ b/resources/js/imageUpload.js
@@ -1,0 +1,60 @@
+/*
+ This file replaces the inline javascript on the profile form.
+ Previously there was only code to update the preview image from the file input field.
+*/
+
+//   document.getElementById('image_thumbnail_preview').src = window.URL.createObjectURL(this.files[0]);
+//   document.getElementById('image_thumbnail_preview_large').src = window.URL.createObjectURL(this.files[0]);
+
+// Install the appropriate event listeners in all candidate elements
+function installImageInputEventHandlers() {
+
+    /*
+     Handle <input type="file" data-file-size-limit="NNN"> where NNN is the maximum length in bytes.
+     Will show an alert box and clear the file selection.
+    */
+    document.querySelectorAll('input[type="file"][data-file-size-limit]').forEach((el) => {
+        const fileSizeLimit = parseInt(el.dataset.fileSizeLimit);
+        // Fired anytime the selected file is changed (this also applies to "cancelling" the picker, removing the image).
+        el.addEventListener('change', () => {
+            const file = el.files[0];
+            console.log({fsl:file})
+            if (file && file.size > fileSizeLimit) {
+                alert('The file you chose is too big (file size)!');
+                // Clear the file field, this also changes the value for subsequent onChange events (see below).
+                el.value = null;
+            }
+        });
+    });
+
+    /*
+     Handle <input type="file" data-image-preview-targets="AAA,BBB"> where AAA, BBB are IDs of img-Tags.
+     Will replace the src of all img tags given by the selected source file.
+    */
+    document.querySelectorAll('input[type="file"][data-image-preview-targets]').forEach((el) => {
+        // Split the list of IDs into an array
+        const imagePreviewTargets = el.dataset.imagePreviewTargets.split(',');
+        // Get the elements, filter out those which did not resolve (just for safety)
+        const targetElements =  imagePreviewTargets.map((id) => document.getElementById(id)).filter((el) => !!el);
+        // Store the initial src
+        targetElements.forEach((tel) => {
+            if (!tel.dataset.originalSrcValue) {
+                tel.dataset.originalSrcValue = tel.src;
+            }
+        });
+        // Fired anytime the selected file is changed (this also applies to "cancelling" the picker, removing the image).
+        el.addEventListener('change', () => {
+            const file = el.files[0];
+            console.log({pec:file})
+            if (file) {
+                const newSrc = window.URL.createObjectURL(file);
+                targetElements.forEach((tel) => tel.src = newSrc);
+            } else {
+                targetElements.forEach((tel) => tel.src = tel.dataset.originalSrcValue);
+            }
+        });
+    });
+
+}
+
+installImageInputEventHandlers();

--- a/resources/views/forms/profile.blade.php
+++ b/resources/views/forms/profile.blade.php
@@ -34,11 +34,12 @@
                     <div class="col-sm-10">
                         <input id="image_thumbnail" type="file"
                             class="form-control @error('image_thumbnail') is-invalid @enderror" name="image_thumbnail"
-                            accept="image/jpeg, image/png"
-                            onchange="document.getElementById('image_thumbnail_preview').src = window.URL.createObjectURL(this.files[0]); document.getElementById('image_thumbnail_preview_large').src = window.URL.createObjectURL(this.files[0]);">
+                            accept="image/jpeg, image/png" data-file-size-limit="{{ 1*1024*1024 }}"
+                            data-image-preview-targets="image_thumbnail_preview,image_thumbnail_preview_cropped,image_thumbnail_preview_large">
                         <div id="image_thumbnailHelp" class="form-text">Upload an image to be shown next to your name in
                             the dealer list. This image should have a size of 60&times;60 pixels (max file size is 1
-                            MB).
+                            MB).<br>
+                            <b>Please note:</b> This image will also be shown cropped to a circle in some places, so make sure the relevant content is visible!
                         </div>
                         @error('image_thumbnail')
                             <span class="invalid-feedback" role="alert">
@@ -46,10 +47,14 @@
                             </span>
                         @enderror
 
-                        <img id='image_thumbnail_preview' class="mx-auto mb-2" data-bs-toggle="modal"
+                        <img id='image_thumbnail_preview' class="mx-auto my-2" data-bs-toggle="modal"
                             data-bs-target="#imageThumbnailModal"
                             src="{{ Storage::disk('public')->url("$profile?->image_thumbnail") }}" alt=""
                             style="height: 100px;">
+                        <img id='image_thumbnail_preview_cropped' class="mx-auto my-2 ms-2" data-bs-toggle="modal"
+                             data-bs-target="#imageThumbnailModal"
+                             src="{{ Storage::disk('public')->url("$profile?->image_thumbnail") }}" alt=""
+                             style="height: 100px; border-radius: 50px; outline: 4px solid rgb(0 0 0 / 50%); outline-offset: -4px;">
 
                         <!-- Modal -->
                         <div class="modal fade" id="imageThumbnailModal" tabindex="-1"
@@ -61,7 +66,7 @@
                                             aria-label="Close"></button>
                                     </div>
                                     <div class="modal-body">
-                                        <img id='image_thumbnail_preview_large'class="mx-auto d-block w-100"
+                                        <img id='image_thumbnail_preview_large' class="mx-auto d-block w-100"
                                             src="{{ Storage::disk('public')->url("$profile?->image_thumbnail") }}"
                                             alt="">
                                     </div>
@@ -158,8 +163,8 @@
 
                         <input id="image_artist" type="file"
                             class="form-control @error('image_artist') is-invalid @enderror" name="image_artist"
-                            accept="image/jpeg, image/png"
-                            onchange="document.getElementById('image_artist_preview').src = window.URL.createObjectURL(this.files[0]); document.getElementById('image_artist_preview_large').src = window.URL.createObjectURL(this.files[0]);">
+                            accept="image/jpeg, image/png" data-file-size-limit="{{ 1*1024*1024 }}"
+                            data-image-preview-targets="image_artist_preview,image_artist_preview_large">
                         <div id="image_artistHelp" class="form-text">This image is shown on your dedicated page in the
                             EF
                             app.
@@ -173,7 +178,7 @@
                         <img id='image_artist_preview' class="mx-auto mb-2" data-bs-toggle="modal"
                             data-bs-target="#imageArtistModal"
                             src="{{ Storage::disk('public')->url("$profile?->image_artist") }}" alt=""
-                            style="height: 100px;">
+                            style="height: 100px; aspect-ratio: 1; object-fit: cover;">
 
                         <!-- Modal -->
                         <div class="modal fade" id="imageArtistModal" tabindex="-1"
@@ -186,6 +191,7 @@
                                     </div>
                                     <div class="modal-body">
                                         <img id='image_artist_preview_large' class="mx-auto d-block w-100"
+                                            style="aspect-ratio: 1; object-fit: cover; max-height: 75vh;"
                                             src="{{ Storage::disk('public')->url("$profile?->image_artist") }}"
                                             alt="">
                                     </div>
@@ -216,8 +222,8 @@
                     <div class="col-sm-10">
                         <input id="image_art" type="file"
                             class="form-control @error('image_art') is-invalid @enderror" name="image_art"
-                            accept="image/jpeg, image/png"
-                            onchange="document.getElementById('image_art_preview').src = window.URL.createObjectURL(this.files[0]); document.getElementById('image_art_preview_large').src = window.URL.createObjectURL(this.files[0]);">
+                            accept="image/jpeg, image/png" data-file-size-limit="{{ 1*1024*1024 }}"
+                            data-image-preview-targets="image_art_preview,image_art_preview_large">
                         <div id="image_artHelp" class="form-text">You can upload a preview image of your art or
                             merchandise,
                             which will be shown on your dedicated page in the EF app. The size of this image should be
@@ -232,7 +238,7 @@
                         <img id='image_art_preview' class="mx-auto mb-2" data-bs-toggle="modal"
                             data-bs-target="#imageArtModal"
                             src="{{ Storage::disk('public')->url("$profile?->image_art") }}" alt=""
-                            style="height: 100px;">
+                            style="height: 100px; aspect-ratio: 40/45; object-fit: cover;">
 
                         <!-- Modal -->
                         <div class="modal fade" id="imageArtModal" tabindex="-1"
@@ -246,6 +252,7 @@
                                     <div class="modal-body">
                                         <img id='image_art_preview_large' class="mx-auto d-block w-100"
                                             src="{{ Storage::disk('public')->url("$profile?->image_art") }}"
+                                            style="aspect-ratio: 40/45; object-fit: cover; max-height: 75vh;"
                                             alt="">
                                     </div>
                                     <div class="modal-footer">


### PR DESCRIPTION
- Fixes error 415 in #118 as it prevents users from getting a server-side error for too big requests by preventing selection of a file bigger than the limit inside the frontend.
- Resolves #185 by adding information text about the circular crop as well as a second preview with the crop
- Improves the upload file preview by enforcing the target aspect ratio using object-fit style. Before, images in the wrong aspect ratio were displayed in full until they were actually resized during the upload server-side.
- Overall improves the javascript on the profile form by moving it into the vite-processed assets and using proper event handlers attaching based on data attributes. 
