### PR TITLE
feat(#207): Chairs Display in Frontdesk and Admin

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -579,7 +579,9 @@ class Application extends Model
                 'canceled_at',
                 'profiles.*',
                 'profile_keywords.keywords',
-                'profile_keywords.categories'
+                'profile_keywords.categories',
+                't2.seats AS physical_chairs_default',
+                'physical_chairs AS physical_chairs_requested'
             )
             ->get();
 

--- a/app/Services/ProfileCompletionEvaluator.php
+++ b/app/Services/ProfileCompletionEvaluator.php
@@ -194,7 +194,7 @@ class ProfileCompletionEvaluator
             }
             $this->maxProgress = floor($maxProgress);
             $this->weightedMaxProgress = floor($weightedMaxProgress);
-            $this->weightedPercent = floor(100*$weightedProgress) / $weightedMaxProgress;
+            $this->weightedPercent = floor(100*$weightedProgress / max(1,$weightedMaxProgress));
             $this->progress = floor($progress);
             $this->weightedProgress = floor($weightedProgress);
         }

--- a/resources/views/frontdesk.blade.php
+++ b/resources/views/frontdesk.blade.php
@@ -433,6 +433,7 @@
                                         @else
                                             n/a
                                         @endif
+                                        <div>Phyiscal Chairs: <b>{{ $application->parent?->phyiscal_chairs ?? $application->physical_chairs }}</b></div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Adds the physical chair count information to the frontdesk view as well as the admin export table.
Collateral fix: Profile Competion Display caused a divide-by-zero bug when showing a fresh create-application form.