### PR TITLE
fix(admin/badges): More robust font management

### DIFF
--- a/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
+++ b/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
@@ -81,9 +81,9 @@ class BadgeSettings extends Page implements HasForms, HasActions
 
         if (Storage::disk('local')->exists('badges/badgefont.json')) {
             // Delete the old processed font
-            Storage::disk('local')->delete('badgefont.ctg.z');
-            Storage::disk('local')->delete('badgefont.z');
-            Storage::disk('local')->delete('badgefont.json');
+            Storage::disk('local')->delete('badges/badgefont.json');
+            Storage::disk('local')->delete('badges/badgefont.ctg.z');
+            Storage::disk('local')->delete('badges/badgefont.z');
         }
 
         // Try to import the font immediately, this makes font errors more apparent

--- a/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
+++ b/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
@@ -13,10 +13,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Resources\Pages\Page;
-use Filament\Support\Facades\FilamentIcon;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\HtmlString;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class BadgeSettings extends Page implements HasForms, HasActions
@@ -80,6 +77,33 @@ class BadgeSettings extends Page implements HasForms, HasActions
     {
         // Force processing of the uploaded files
         $this->form->getState();
+
+
+        if (Storage::disk('local')->exists('badges/badgefont.json')) {
+            // Delete the old processed font
+            Storage::disk('local')->delete('badgefont.ctg.z');
+            Storage::disk('local')->delete('badgefont.z');
+            Storage::disk('local')->delete('badgefont.json');
+        }
+
+        // Try to import the font immediately, this makes font errors more apparent
+        try {
+            new \Com\Tecnick\Pdf\Font\Import(Storage::disk('local')->path('badges/badge-font'));
+        }
+        catch (\Com\Tecnick\File\Exception $e) {
+            Notification::make()
+                ->danger()
+                ->title("Font file not found, server side error? ".$e->getMessage())
+                ->send();
+                return;
+        }
+        catch (\Com\Tecnick\Pdf\Font\Exception $e) {
+            Notification::make()
+                ->danger()
+                ->title("Failed to import font, parser reports: ".$e->getMessage())
+                ->send();
+                return;
+        }
 
         Notification::make()
             ->success()

--- a/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
+++ b/app/Filament/Resources/BadgeResource/Pages/BadgeSettings.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\BadgeResource\Pages;
 
 use App\Filament\Resources\BadgeResource;
+use Com\Tecnick\Pdf\Tcpdf;
 use Filament\Actions\Action;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Contracts\HasForms;
@@ -88,7 +89,30 @@ class BadgeSettings extends Page implements HasForms, HasActions
 
         // Try to import the font immediately, this makes font errors more apparent
         try {
-            new \Com\Tecnick\Pdf\Font\Import(Storage::disk('local')->path('badges/badge-font'));
+            if (!defined('K_PATH_FONTS')) {
+                // Since the library is bad at combining path elements, ensure path has a final slash
+                $path = Storage::disk('local')->path('badges');
+                if (substr($path, -1) !== '/') {
+                    $path .= '/';
+                }
+                define('K_PATH_FONTS', $path);
+            }
+            $pdf = new Tcpdf(
+                unit: 'mm',    // Use millimetres as unit,
+                isunicode: true,    // Unicode document,
+                subsetfont: false,   // Embed full fonts,
+                compress: true,    // Use stream compression,
+                mode: 'pdfa3', // Conform to PDF/A-3,
+                objEncrypt: null,    // Don't use encryption,
+            );
+            $pdf->initClassObjects(fileOptions: [
+                'allowedPaths' => array_merge(
+                    $pdf->defaultFileAllowedPaths(),
+                    [Storage::disk('local')->path('badges')])
+            ]);
+
+            $font_file = Storage::disk('local')->path('badges/badge-font');
+            new \Com\Tecnick\Pdf\Font\Import($font_file);
         }
         catch (\Com\Tecnick\File\Exception $e) {
             Notification::make()

--- a/app/Services/BadgeService.php
+++ b/app/Services/BadgeService.php
@@ -50,7 +50,12 @@ class BadgeService
             ]);
 
         if (!defined('K_PATH_FONTS')) {
-            define('K_PATH_FONTS', Storage::disk('local')->path('badges'));
+            // Since the library is bad at combining path elements, ensure path has a final slash
+            $path = Storage::disk('local')->path('badges');
+            if (substr($path, -1) !== '/') {
+                $path .= '/';
+            }
+            define('K_PATH_FONTS', $path);
         }
         if (!Storage::disk('local')->exists('badges/badgefont.json')) {
             new \Com\Tecnick\Pdf\Font\Import(Storage::disk('local')->path('badges/badge-font'));


### PR DESCRIPTION
The previous version did not regenerate the font files on-upload, this version adds support for cleanup and regenration of the parsed font files on upload.

Similarly, a previously removed trailing slash from the font path struck again, it is now back.